### PR TITLE
fix(csv): manually encode CSV output to support utf-8-sig

### DIFF
--- a/superset/commands/sql_lab/export.py
+++ b/superset/commands/sql_lab/export.py
@@ -131,7 +131,8 @@ class SqlResultExportCommand(BaseCommand):
                 self._query.schema,
             )[:limit]
 
-        csv_data = csv.df_to_escaped_csv(df, index=False, **config["CSV_EXPORT"])
+        csv_string = csv.df_to_escaped_csv(df, index=False, **config["CSV_EXPORT"])
+        csv_data = csv_string.encode(config["CSV_EXPORT"].get("encoding", "utf-8"))
 
         return {
             "query": self._query,

--- a/superset/utils/csv.py
+++ b/superset/utils/csv.py
@@ -23,11 +23,9 @@ from urllib.error import URLError
 import numpy as np
 import pandas as pd
 
-from superset import app
 from superset.utils import json
 from superset.utils.core import GenericDataType
 
-config = app.config
 logger = logging.getLogger(__name__)
 
 negative_number_re = re.compile(r"^-[0-9.]+$")
@@ -80,9 +78,7 @@ def df_to_escaped_csv(df: pd.DataFrame, **kwargs: Any) -> Any:
                 if isinstance(value, str):
                     df.at[idx, name] = escape_value(value)
     
-    # Encode using the specified encoding (default to utf-8 if not set)
-    csv_string = df.to_csv(escapechar="\\", **kwargs)
-    return csv_string.encode(config["CSV_EXPORT"].get("encoding", "utf-8"))
+    return df.to_csv(escapechar="\\", **kwargs)
 
 
 def get_chart_csv_data(

--- a/superset/utils/csv.py
+++ b/superset/utils/csv.py
@@ -79,7 +79,8 @@ def df_to_escaped_csv(df: pd.DataFrame, **kwargs: Any) -> Any:
             for idx, value in enumerate(column.values):
                 if isinstance(value, str):
                     df.at[idx, name] = escape_value(value)
-
+    
+    # Encode using the specified encoding (default to utf-8 if not set)
     csv_string = df.to_csv(escapechar="\\", **kwargs)
     return csv_string.encode(config["CSV_EXPORT"].get("encoding", "utf-8"))
 

--- a/superset/utils/csv.py
+++ b/superset/utils/csv.py
@@ -23,9 +23,11 @@ from urllib.error import URLError
 import numpy as np
 import pandas as pd
 
+from superset import app
 from superset.utils import json
 from superset.utils.core import GenericDataType
 
+config = app.config
 logger = logging.getLogger(__name__)
 
 negative_number_re = re.compile(r"^-[0-9.]+$")
@@ -78,7 +80,8 @@ def df_to_escaped_csv(df: pd.DataFrame, **kwargs: Any) -> Any:
                 if isinstance(value, str):
                     df.at[idx, name] = escape_value(value)
 
-    return df.to_csv(escapechar="\\", **kwargs)
+    csv_string = df.to_csv(escapechar="\\", **kwargs)
+    return csv_string.encode(config["CSV_EXPORT"].get("encoding", "utf-8"))
 
 
 def get_chart_csv_data(


### PR DESCRIPTION
Manually encodes the CSV string before returning it in the response. Since `Werkzeug 3` removed support for automatic encoding.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

By manually encoding the string, Superset ensures compatibility with tools like Excel that expect a BOM when reading UTF-8 encoded CSV files.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

<img width="194" height="89" alt="image" src="https://github.com/user-attachments/assets/ba69dd12-7481-4f75-b954-8724a988e85a" />

After:

<img width="199" height="71" alt="image" src="https://github.com/user-attachments/assets/61504a96-1514-4d80-817c-fde0ef50d62f" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #5372, #4506, #29224, #29410, #29506
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
